### PR TITLE
Adds the current user to the path.

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -9,8 +9,8 @@ end
 
 function _drush_alias_name
   set -l pid %self
-  if test -f "$TMPDIR/drush-env/drush-drupal-site-$pid"
-    echo (command cat $TMPDIR/drush-env/drush-drupal-site-$pid)
+  if test -f "$TMPDIR/drush-env-$USER/drush-drupal-site-$pid"
+    echo (command cat $TMPDIR/drush-env-$USER/drush-drupal-site-$pid)
   end
 end
 


### PR DESCRIPTION
On my machine and a few others I tested it on /drush-env/ needs the current username. 
